### PR TITLE
Add hamburger menu (three-line) with Save/Load dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     position: sticky;
     top: 0;
     display: flex;
-    gap: 10px;
+    justify-content: flex-end;
     padding: 12px 20px 0 20px;
     background: linear-gradient(to bottom, #f0f0f0 70%, rgba(240,240,240,0));
     z-index: 10;
@@ -32,6 +32,38 @@
   }
   #controls button:hover {
     background: #fafafa;
+  }
+  .menu {
+    position: relative;
+  }
+  .menu-toggle {
+    width: 40px;
+    height: 36px;
+    padding: 0;
+    font-size: 20px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+  }
+  .menu-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    display: none;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    min-width: 140px;
+    background: white;
+    border: 1px solid rgba(0,0,0,0.15);
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgba(0,0,0,0.15);
+    z-index: 20;
+  }
+  .menu-dropdown.open {
+    display: flex;
   }
   #appContainer {
     position: relative;
@@ -79,9 +111,14 @@
 </head>
 <body>
 <div id="controls">
-  <button id="saveGoalsBtn">Save Goals</button>
-  <input type="file" id="loadGoalsInput" accept="application/json" style="display:none" />
-  <button id="loadGoalsBtn">Load Goals</button>
+  <div class="menu">
+    <button id="menuToggle" class="menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+    <div id="menuDropdown" class="menu-dropdown" role="menu">
+      <button id="saveGoalsBtn" role="menuitem">Save Goals</button>
+      <button id="loadGoalsBtn" role="menuitem">Load Goals</button>
+      <input type="file" id="loadGoalsInput" accept="application/json" style="display:none" />
+    </div>
+  </div>
 </div>
 <div id="appContainer">
   <svg id="connections"></svg>
@@ -100,11 +137,34 @@ const svg = document.getElementById('connections');
 const saveBtn = document.getElementById('saveGoalsBtn');
 const loadBtn = document.getElementById('loadGoalsBtn');
 const loadInput = document.getElementById('loadGoalsInput');
+const menuToggle = document.getElementById('menuToggle');
+const menuDropdown = document.getElementById('menuDropdown');
 initTopLevelGoal();
 recalcAndRender();
 saveBtn.addEventListener('click', saveGoalsToFile);
 loadBtn.addEventListener('click', () => loadInput.click());
 loadInput.addEventListener('change', handleLoadInputChange);
+menuToggle.addEventListener('click', (event) => {
+  event.stopPropagation();
+  const isOpen = menuDropdown.classList.toggle('open');
+  menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+});
+menuDropdown.addEventListener('click', () => {
+  menuDropdown.classList.remove('open');
+  menuToggle.setAttribute('aria-expanded', 'false');
+});
+document.addEventListener('click', (event) => {
+  if (!menuDropdown.classList.contains('open')) return;
+  if (menuDropdown.contains(event.target) || menuToggle.contains(event.target)) return;
+  menuDropdown.classList.remove('open');
+  menuToggle.setAttribute('aria-expanded', 'false');
+});
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  if (!menuDropdown.classList.contains('open')) return;
+  menuDropdown.classList.remove('open');
+  menuToggle.setAttribute('aria-expanded', 'false');
+});
 function initTopLevelGoal() {
   const id = generateId();
   const newGoal = {


### PR DESCRIPTION
### Motivation
- Provide a sleek, modern compact control in the top-right for Save and Load actions using a three-line (hamburger) icon.  
- Replace the previous visible top controls with a right-aligned dropdown to declutter the UI.  
- Improve accessibility and UX by adding keyboard and outside-click behavior for the menu.  

### Description
- Restyles `#controls` to right-align and adds new CSS for `.menu`, `.menu-toggle`, and `.menu-dropdown` to render a hamburger button and dropdown.  
- Moves the Save/Load buttons and the hidden file input into a new `.menu` element and renders the hamburger button `☰` as `#menuToggle`.  
- Adds JavaScript to wire `menuToggle`/`menuDropdown` behavior: toggle open/close, set `aria-expanded`, close on outside click or `Escape`, and auto-close on menu item click.  
- Keeps existing `saveGoalsToFile`/`handleLoadInputChange` wiring so saving and loading functionality is unchanged.  

### Testing
- Started a local static server using `python -m http.server 8000` to serve the updated `index.html`, which launched successfully.  
- Attempted to run a Playwright script to open the page, click `#menuToggle`, and capture a screenshot, but the browser crashed in this environment and the Playwright run failed.  
- No additional automated unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2b7696ec832f810a3d5d3c154148)